### PR TITLE
Use `scrub_tables` configuration key for tables to exclude data for.

### DIFF
--- a/src/DatabaseJanitor.php
+++ b/src/DatabaseJanitor.php
@@ -60,7 +60,7 @@ class DatabaseJanitor {
     $dumpSettings = [
       'add-locks' => FALSE,
       'exclude-tables' => $this->dumpOptions['excluded_tables'] ?? [],
-      'no-data' => $this->dumpOptions['no-data'] ?? [],
+      'no-data' => $this->dumpOptions['scrub_tables'] ?? [],
       'keep-data' => $this->dumpOptions['keep_data'] ?? [],
     ];
 


### PR DESCRIPTION
For #19, this set Ifsnop/Mysqldump's `no-data` option to the list of tables from the `scrub_tables` configuration.