### PR TITLE
Adding sanitize_tables_default option to set the default value for a column.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ sanitize_tables:
   # List of tables and their columns you want sanitized.
   user:
   - mail
+sanitize_tables_default:
+  node:
+    uid: 1
+  node_revision:
+    uid: 1
 trim_tables:
 # List of tables to be trimmed (every 4th row kept)
   - trim1

--- a/src/DatabaseJanitor.php
+++ b/src/DatabaseJanitor.php
@@ -154,6 +154,18 @@ class DatabaseJanitor {
       }
     }
 
+    if (isset($options['sanitize_tables_default'])) {
+      foreach ($options['sanitize_tables_default'] as $table => $val) {
+        if ($table == $table_name) {
+          foreach ($options['sanitize_tables_default'][$table] as $col => $val) {
+            if ($col == $col_name) {
+              return $val;
+            }
+          }
+        }
+      }
+    }
+
     return $col_value;
   }
 


### PR DESCRIPTION
Currently, there is no support if we want to set a default value to a column which has reference to another table. Consider, we want to truncate the user table except the uid 0 and 1 and we want to replace the node's author to uid 1.

I have created a solution for it.